### PR TITLE
feat: create media match component

### DIFF
--- a/src/components/MediaMatch/index.tsx
+++ b/src/components/MediaMatch/index.tsx
@@ -1,0 +1,29 @@
+import styled, { css } from 'styled-components';
+
+import media, { DefaultBreakpoints } from 'styled-media-query';
+
+type breakpoint = keyof DefaultBreakpoints;
+
+export type MediaMatchProps = {
+  lessThan?: breakpoint;
+  greaterThan?: breakpoint;
+};
+
+const mediaMatchModifier = {
+  lessThan: (size: breakpoint) => css`
+    ${media.lessThan(size)` display: block `}
+  `,
+
+  greaterThan: (size: breakpoint) => css`
+    ${media.greaterThan(size)` display: block `}
+  `
+};
+
+export default styled.div<MediaMatchProps>`
+  ${({ lessThan, greaterThan }) => css`
+    display: none;
+
+    ${!!lessThan && mediaMatchModifier.lessThan(lessThan)}
+    ${!!greaterThan && mediaMatchModifier.greaterThan(greaterThan)}
+  `}
+`;

--- a/src/components/MediaMatch/mediaMatch.spec.tsx
+++ b/src/components/MediaMatch/mediaMatch.spec.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import MediaMatch from '.';
+import 'jest-styled-components';
+
+describe('<MediaMatch />', () => {
+  let desktopHeading: Element;
+  let mobileHeading: Element;
+
+  beforeEach(() => {
+    render(
+      <>
+        <MediaMatch greaterThan="medium">
+          <h1 data-testid="desktop">Desktop</h1>
+        </MediaMatch>
+        <MediaMatch lessThan="medium">
+          <h1 data-testid="mobile">Mobile</h1>
+        </MediaMatch>
+      </>
+    );
+
+    desktopHeading = screen.getByTestId('desktop');
+    mobileHeading = screen.getByTestId('mobile');
+  });
+
+  it('should be hidden if no media query is passed', () => {
+    expect(desktopHeading.parentElement).toHaveStyleRule('display', 'none');
+    expect(mobileHeading.parentElement).toHaveStyleRule('display', 'none');
+  });
+
+  it('should show or hide based on the media passed', () => {
+    expect(desktopHeading.parentElement).toHaveStyleRule('display', 'block', {
+      media: '(min-width:  768px)'
+    });
+
+    expect(mobileHeading.parentElement).toHaveStyleRule('display', 'block', {
+      media: '(max-width:  768px)'
+    });
+  });
+});

--- a/src/components/MediaMatch/stories.tsx
+++ b/src/components/MediaMatch/stories.tsx
@@ -1,0 +1,34 @@
+import { Meta, StoryObj } from '@storybook/react';
+import MediaMatch, { MediaMatchProps } from '.';
+
+export default {
+  title: 'MediaMatch',
+  component: MediaMatch
+} as Meta;
+
+export const Desktop: StoryObj<MediaMatchProps> = {
+  args: {
+    greaterThan: 'medium'
+  },
+  render: (args) => (
+    <MediaMatch {...args}>
+      <h1>Desktop</h1>
+    </MediaMatch>
+  )
+};
+
+export const Mobile: StoryObj<MediaMatchProps> = {
+  args: {
+    lessThan: 'medium'
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1'
+    }
+  },
+  render: (args) => (
+    <MediaMatch {...args}>
+      <h1>Mobile</h1>
+    </MediaMatch>
+  )
+};


### PR DESCRIPTION
- [x] Add tests
- [x] Add component
- [x] Add doc in storybook

Media Match conditionally render its content based on media query breakpoints. 
This component is useful for responsive design, allowing developers to show or hide content based on the screen size.

